### PR TITLE
Fix type assignment in singleton case

### DIFF
--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -40,8 +40,9 @@ module Axlsx
       # And do not call parse_options on frequently used options
       # to get less GC cycles
       type = options.delete(:type) || cell_type_from_value(value)
-      self.type = type unless type == :string
-
+      if self.type != type
+        self.type = type
+      end
 
       val = options.delete(:style)
       self.style = val unless val.nil? || val == 0


### PR DESCRIPTION
Because we re-use Cell instance, we have to set type correctly.

In original design, we only set self.type if type is not string.

However, if we re-use the instance, the self.type may be :integer but
we may not assign self.type value even `cell_type_from_value` return
:string type.

Original design is to save memory, and the current implementation does
not violate the objective, because in the newly created Cell instance,
which does not have self.type defined, self.type will be :string and
the assignment will not performed since `self.type != type`.